### PR TITLE
Block /gadmin and /toggle

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -101,6 +101,8 @@ blocked_commands:
   - 'n:b:/save-all:_'
   - 'n:b:/save-on:_'
   - 'n:b:/save-off:_'
+  - 's:b:/gadmin:_'
+  - 's:b:/toggle:_'
 
   # Superadmin commands
   - 's:b:/kick:_'


### PR DESCRIPTION
I saw people on a different server using /gadmin and /toggle somehow to completely break the server. The server currently cannot start.
I want to prevent this hopefully and this should help.
Only SA+ can use it fully, but just in case.